### PR TITLE
Add GitHub action to auto-assign and label pull requests

### DIFF
--- a/.github/workflows/auto-assign-label-pr.yml
+++ b/.github/workflows/auto-assign-label-pr.yml
@@ -1,0 +1,26 @@
+name: Auto Assign and Label PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-and-label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Add Labels to PR
+      uses: actions-ecosystem/action-add-labels@v1.1.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: gssoc-ext
+
+    - name: Assign PR to Creator
+      uses: actions-ecosystem/action-assign@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        assignees: ${{ github.actor }}


### PR DESCRIPTION
Add a new GitHub action to auto-assign pull requests to the creator and label them with `gssoc-ext`.

* Create `.github/workflows/auto-assign-label-pr.yml` file
* Define the name of the action as "Auto Assign and Label PR"
* Trigger the action on `pull_request_target` event with `types: [opened]`
* Use `actions-ecosystem/action-add-labels@v1.1.1` to add the `gssoc-ext` label
* Use `actions-ecosystem/action-assign@v1` to assign the pull request to the creator