### PR TITLE
fix : popup email placeholder box width

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -89,7 +89,7 @@
   }
 
   input[type="email"] {
-    width: 100%;
+    width: 93%;
     padding: 10px;
     margin-bottom: 16px;
     border: 1px solid #000000;


### PR DESCRIPTION
### Issue #523  : "Enter your email placeholder box width" solved

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): ___________  


## Description
I increased the the popup container email placeholder box width to befit this it into the container to look good.

## Screenshots / Videos (if applicable)
**Before:**
![377367660-cd4cec9d-ee8a-45b5-81bd-c13dcf814147](https://github.com/user-attachments/assets/c1647552-a98e-4f8b-b38f-10af86a7a561)

**After:**
![image](https://github.com/user-attachments/assets/9138ba46-9a7e-4c8a-a357-c6ed484267a9)

## Checklist
- **Add X in the box to specify.**
- [X] I have performed a self-review of my code.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.

Thank you for reviewing my pull request!
