### PR TITLE
Made `email` & `phone no` launchable on clicking link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,9 +643,9 @@
                     selection of controllers, VR gear, and more.
                 </p>
                 <div class="contact">
-                    <span><i class="fas fa-phone"></i> &nbsp; 123-456-789</span>
-                    <span><i class="fas fa-envelope"></i> &nbsp; info@gamingtools.com</span>
-                </div>
+                    <span><a href="tel:123-456-789" style="color: white; text-decoration: none;"><i class="fas fa-phone"></i> &nbsp; 123-456-789</a></span>
+                    <span><a href="mailto:info@gamingtools.com" style="color: white; text-decoration: none;"><i class="fas fa-envelope"></i> &nbsp; info@gamingtools.com</a></span>
+                </div>                              
                 <div class="socials">
                     <!-- Added classes to the <a> tags to add the Hover animations -->
                     <a class="facebook" href="#"><i class="fab fa-facebook"></i></a>


### PR DESCRIPTION

### Issue #589  : **[BUG]  Footer `email` and `phone no`  aren't clickable and hence not launching gmail on clicking** (solved)

## Type of PR

- [X] Bug fix



## Description
Made `email` & `phone no` launchable on clicking link in footer

## Screenshots / Videos (if applicable)
- updated footer
![Screenshot 2024-10-20 095210](https://github.com/user-attachments/assets/a9a7a2b3-0177-4360-8522-896e6840a9b0)
- launchable email
![Screenshot 2024-10-20 095237](https://github.com/user-attachments/assets/8699be8a-fd41-4d7d-b378-e76e41fc1c54)
- launchable phone no.
![Screenshot 2024-10-20 095252](https://github.com/user-attachments/assets/294213a8-9796-410a-a7a7-ead5312e70ce)


## Checklist

- [X] I have performed a self-review of my code.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

@swaraj-das please review my pr
