### PR TITLE
Fixed cart button

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -183,12 +183,11 @@
                 <li class="login"><a href="login/login.html">Login</a></li>
 
                 <!-- Inside the navbar ul -->
-                <li class="cart-nav">
-
-                    <a href="#"><img height="25px " width="25px" src="images/cart.png" alt="Cart Icon"> <span
-                            id="cart-count">0</span></a>
-
-                </li>
+                
+                <a href="#" class="cart-button">
+                    <img src="images/cart.png" alt="Cart Icon">
+                    <span id="cart-count">0</span>
+                    </a>
 
             </ul>
 


### PR DESCRIPTION
## Fixed Cart Button in About-Us Page
### Issue #529 : **The Cart icon is not visible in About Us Page solved** solved

## Type of PR
- [X] Bug fix

## Description
This pull request aims to to fix the Cart icon which is not visible in the About-Page but now it fixed and designed in a way the repo owners asked

## Screenshots 
**Before:**
The cart icon is not visible in about us page 
![1](https://github.com/user-attachments/assets/13fd128d-9814-4bc6-81fc-8c740952e327)


**After:**
Now its visible in about us page
- 
![2](https://github.com/user-attachments/assets/db0350c6-129b-491f-b468-7f70695d1045)


## Checklist
- **Add X in the box to specify.**
- [X] I have performed a self-review of my code.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


Thank you for reviewing my pull request!
