### PR TITLE
fix: fixed the about us page cards dark mode

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -77,6 +77,8 @@
             text-align: center;
         }
 
+    
+
         .feature:hover {
             transform: translateX(-5px);
             box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.15);

--- a/style.css
+++ b/style.css
@@ -475,7 +475,10 @@ nav ul li.login:hover {
   color: #ccc;
 }
 .dark-mode .feature p {
-    color: #000; /* Set paragraph color to black */
+    color: whitesmoke; /* Set paragraph color to black */
+}
+.dark-mode .feature{
+  background: #111111;
 }
 
 .col-1 h3 {


### PR DESCRIPTION
### Issue #624  : **About page cards not responding in dark mode** solved

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): ___________  


## Description
 
fixes #624 i have fixed the about  us page cards theme which are now responding in the dark mode.

## Screenshots / Videos (if applicable)
**Before:**
 
![image](https://github.com/user-attachments/assets/948a47dc-5b2a-424e-bc7e-9711192106e3)


**After:**
![image](https://github.com/user-attachments/assets/8ca52d63-439d-4810-8857-338ff4231626)


## Checklist

- [X] I have performed a self-review of my code.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.



Thank you for reviewing my pull request!
