### PR TITLE
spacing-between-testimonial-content-and-slide-pagination

### DIFF
--- a/style.css
+++ b/style.css
@@ -1778,7 +1778,7 @@ button {
 
 .swiper-pagination {
   position: relative;
-  bottom: 1px !important;
+  bottom: -20px !important;
   text-align: center;
   margin: 28px;
 }


### PR DESCRIPTION
# Pull Request Format
## PR Title : spacing-between-testimonial-content-and-slide-pagination
### Issue #686 : **Rating overlapping with the slider in tetimonial** solved

## Type of PR
- **Add X in the box to specify the improvement type.**
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): ___________  


## Description
Changes have been made to ensure there is gap between testimonial card content and the slide pagination.

## Screenshots / Videos (if applicable)
**Before:** 
![Screenshot 2024-10-25 195655](https://github.com/user-attachments/assets/6ad72b84-1e53-40c1-8119-7cb31274dd44)

- There was not much gap between the slide pagination and the content

**After:** 
![Screenshot 2024-10-30 104038](https://github.com/user-attachments/assets/b383ad29-e6d2-426b-855c-016e219baf21)


- There is gap between the slide pagination and the content

## Checklist
- **Add X in the box to specify.**
- [X] I have performed a self-review of my code.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


Thank you for reviewing my pull request!
