### PR TITLE
💥FIX : Missing Total Contributions number on Contributors page

### DIFF
--- a/contributor/contributor.js
+++ b/contributor/contributor.js
@@ -1,4 +1,3 @@
-
 // Fetch data from GitHub API
 async function fetchData() {
   try {
@@ -27,13 +26,13 @@ async function fetchData() {
 }
 
 // Render stats
-function renderStats(repoStats, contributorsCount) {
+function renderStats(repoStats, contributorsCount, totalContributions) {
   const statsGrid = document.getElementById('statsGrid');
   const stats = [
-      { label: 'Contributors', value: contributorsCount, icon: 'users' },
-      { label: 'Total Contributions', value: repoStats.contributors?.reduce((sum, contributor) => sum + contributor.contributions, 0) || 0, icon: 'git-commit' },
-      { label: 'GitHub Stars', value: repoStats.stargazers_count || 0, icon: 'star' },
-      { label: 'Forks', value: repoStats.forks_count || 0, icon: 'git-branch' }
+    { label: 'Contributors', value: contributorsCount, icon: 'users' },
+    { label: 'Total Contributions', value: totalContributions, icon: 'git-commit' },
+    { label: 'GitHub Stars', value: repoStats.stargazers_count || 0, icon: 'star' },
+    { label: 'Forks', value: repoStats.forks_count || 0, icon: 'git-branch' }
   ];
 
   statsGrid.innerHTML = stats.map(stat => `
@@ -88,7 +87,10 @@ async function init() {
 
   const { contributors, repoStats } = await fetchData();
 
-  renderStats(repoStats, contributors.length);
+  // Calculate total contributions
+  const totalContributions = contributors.reduce((sum, contributor) => sum + contributor.contributions, 0);
+
+  renderStats(repoStats, contributors.length, totalContributions);
   renderContributors(contributors);
 
   loading.style.display = 'none';
@@ -118,4 +120,3 @@ function scrollToContribute() {
 
 // Initialize the page when the DOM is loaded
 document.addEventListener('DOMContentLoaded', init);
-


### PR DESCRIPTION
# Pull Request Format
## PR Title
### Issue #718  **Contributors page Total Contributions number is missing** solved

## Type of PR

- [X] Bug fix


## Description
Contributors page's Total Contributions number was missing. Currently, It shows the exact number of the total contributions.

## Screenshots / Videos (if applicable)
**Before:**
![image](https://github.com/user-attachments/assets/9f177c70-7e71-4e7d-bbaa-fd3515d1dd4b)

**After:**
![image](https://github.com/user-attachments/assets/c0834e9b-18b0-4ecd-9d9d-ce9684616f5b)

## Checklist
- **Add X in the box to specify.**
- [X] I have performed a self-review of my code.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

### Additional Context


Thank you for reviewing my pull request!
